### PR TITLE
General fixes to make user-api work with blip

### DIFF
--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -22,6 +22,8 @@
 
 var util = require('util');
 
+var restify = require('restify');
+
 module.exports = function (envConfig, userService) {
   // We use strict because we're only worried about modern browsers and we should be strict.
   // JSHint actually insists on this and it's a good idea.
@@ -187,6 +189,15 @@ module.exports = function (envConfig, userService) {
     }
 
     userService.addUser(req.params, function (err, result) {
+      if (err != null) {
+        if (err.statuscode != null) {
+          result = err;
+        } else {
+          log.warn(err, 'Unable to add user[%s] to mongo!', req.params.username);
+          res.send(500);
+          return next();
+        }
+      }
       if (result.statuscode == 201) {
         var sessiontoken = getSessionToken(result.detail.userid);
         upsertToken(sessiontoken, function (err, stored) {
@@ -212,7 +223,6 @@ module.exports = function (envConfig, userService) {
           if (result.statuscode == 200) {
             // something was found, let's make sure it's unique
             if (result.detail.length != 1) {
-              log.info(result.detail);
               res.send(500, 'failed to find logged in user!');
             } else {
               res.send(result.statuscode, result.detail[0]);
@@ -232,18 +242,19 @@ module.exports = function (envConfig, userService) {
 
   // login endpoint for humans
   var login = function (req, res, next) {
-    var user = req.headers['x-tidepool-userid'];
-    var pw = req.headers['x-tidepool-password'];
+    if (req.authorization == null || req.authorization.basic == null) {
+      res.send(400, 'Missing login information');
+    }
+
+    var user = req.authorization.basic.username;
+    var pw = req.authorization.basic.password;
 
     if (!(user && pw)) {
       res.send(400, 'Missing login information');
       return next();
     }
 
-    var userinfo = {
-      user: user,
-      password: pw
-    };
+    var userinfo = { user: user, password: pw };
     userService.getUser(userinfo, function (err, result) {
       if (result.statuscode == 200) {
         // something was found, let's make sure it's unique
@@ -255,7 +266,7 @@ module.exports = function (envConfig, userService) {
           var sessiontoken = getSessionToken(result.detail[0].userid);
           upsertToken(sessiontoken, function (err, stored) {
             res.header('x-tidepool-session-token', sessiontoken);
-            res.send(result.statuscode, result.msg);
+            res.send(result.statuscode, _.pick(result.detail[0], 'userid', 'username', 'emails'));
             return next();
           });
         }
@@ -456,7 +467,7 @@ module.exports = function (envConfig, userService) {
     { path: '/user', verb: 'post', func: createUser },
     { path: '/user', verb: 'get', func: getUserInfo },
     { path: '/user/:userid', verb: 'get', func: getUserInfo },
-    { path: '/login', verb: 'post', func: login },
+    { path: '/login', verb: 'post', func: [ restify.authorizationParser(), login ] },
     { path: '/login', verb: 'get', func: refreshSession },
     { path: '/serverlogin', verb: 'post', func: serverLogin },
     { path: '/token/:token', verb: 'get', func: [requireServerToken, serverCheckToken] },

--- a/test/test_user_api_unit.js
+++ b/test/test_user_api_unit.js
@@ -136,8 +136,7 @@ describe('userapi', function () {
     it('should respond with 401', function (done) {
       supertest
         .post('/login')
-        .set('X-Tidepool-UserID', 'badid')
-        .set('X-Tidepool-Password', 'abcdef1234567890')
+        .auth('badid', 'abcdef1234567890')
         .expect(401)
         .end(function (err, res) {
           if (err) return done(err);
@@ -196,8 +195,7 @@ describe('userapi', function () {
       it('should respond with 401', function (done) {
         supertest
           .post('/login')
-          .set('X-Tidepool-UserID', user.username)
-          .set('X-Tidepool-Password', user.password + 'x')
+          .auth(user.username, user.password + 'x')
           .expect(401)
           .end(done);
       });
@@ -208,8 +206,7 @@ describe('userapi', function () {
       it('should respond with 200 and a session token', function (done) {
         supertest
           .post('/login')
-          .set('X-Tidepool-UserID', user.username)
-          .set('X-Tidepool-Password', user.password)
+          .auth(user.username, user.password)
           .expect(200)
           .end(function (err, obj) {
             if (err) return done(err);


### PR DESCRIPTION
In integrating blip, I noticed two things:

1) Setting up CORS headers for the username and password headers was annoying.  Talked with Kent and he agreed that switching to HTTP basic auth made sense.

2) The error handling was a little wonky, so, I added some logic to handle the one case I ran into.

@kentquirk @jh-bate If you get a chance to look at this as well, I'd appreciate it.  It's much smaller than the styx changes, so if you pick one, check out this one.
