### PR TITLE
Add throttling to the user-api

### DIFF
--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -94,7 +94,13 @@ module.exports = function (envConfig, userService) {
   };
 
   var unpackSessionToken = function (token) {
-    var unpacked = jwt.decode(token, secret);
+    try {
+      var unpacked = jwt.decode(token, secret);
+    } catch (e) {
+      // if the decrypt fails this will throw, so we can just return nothing and move on
+      return null;
+    }
+
     if (parseInt(unpacked.exp, 10) > parseInt(moment().valueOf(), 10)) {
       return unpacked;
     } else {
@@ -488,28 +494,78 @@ module.exports = function (envConfig, userService) {
     });
   };
 
-  // We need to have sensible responses for all the standard verbs, so we've got a system that makes
-  // it easy to reuse the same handlers for different verbs.
+  var testThrottle = function (req, res, next) {
+    res.send(200);
+  };
 
-  // API
-  // every individual is a user. users have a unique id which they normally don't see; they
-  // identify with their username. Users may have the doctor bit set; if so, they'll see
-  // any doctor-specific features, and they can be searched for when a patient is setting
-  // up an account.
-  // Users may also have the patient bit set; if they do, there is an event stream set up for them.
+  // lets us throttle an api call by IP address
+  // If someone is running multiple sessions on the same machine, 
+  // it still lets us keep them from burning us out
+  var limitIP = function(burst, rate) {
+    if (burst == null) { burst = 40; }
+    if (rate == null) { rate = 10; }
+    var ipthrottle = restify.throttle({
+      burst: burst,
+      rate: rate,
+      ip: true
+    });
+    return function(req, res, next) {
+      if (req.doNotThrottle) {
+        return next();
+      } else {
+        return ipthrottle(req, res, next);
+      }
+    };
+  };
+
+  // lets us throttle an api call by token
+  // this should be run before limitIP to let server tokens
+  // not be throttled
+  var limitTok = function(burst, rate) {
+    if (burst == null) { burst = 20; }
+    if (rate == null) { rate = 5; }
+    var tokenthrottle = restify.throttle({
+      burst: burst,
+      rate: rate,
+      username: true,
+    });
+    return function(req, res, next) {
+      var tok = req.headers['x-tidepool-session-token'];
+      if (tok != null) {
+        var tokdata = unpackSessionToken(tok);
+        if (tokdata && (tokdata.svr === 'yes')) {
+          req.doNotThrottle = true;
+          return next();
+        }
+      }
+      // we use the username field to store the token so we can leverage 
+      // the throttle feature of restify that knows about username
+      req.username = tok;
+      return tokenthrottle(req, res, next);
+    };
+  };
+
+  // This is where the behaviors are defined
+
+  // all requests are throttled by ip address and by token
+  // server tokens are not throttled
+  // Status is limited to 1 call every 5 sec
+  // User creation, deletion, login, refresh are limited to 1 call every 10 sec after a burst
+  // Normal updates are 
   var v01api = [
-    { path: '/status', verb: 'get', func: status },
-    { path: '/user', verb: 'post', func: createUser },
-    { path: '/user', verb: 'get', func: getUserInfo },
-    { path: '/user', verb: 'del', func: deleteUser },
-    { path: '/user/:userid', verb: 'get', func: getUserInfo },
-    { path: '/user/:userid', verb: 'del', func: deleteUser },
-    { path: '/login', verb: 'post', func: [ restify.authorizationParser(), login ] },
-    { path: '/login', verb: 'get', func: refreshSession },
-    { path: '/serverlogin', verb: 'post', func: serverLogin },
+    { path: '/status', verb: 'get', func: [limitTok(3, 0.2), limitIP(3, 0.2), status] },
+    { path: '/test/throttle', verb: 'get', func: [limitTok(100, 50), limitIP(3, 0.25), testThrottle] },
+    { path: '/user', verb: 'post', func: [limitTok(10, 0.1), limitIP(10, 0.1), createUser] },
+    { path: '/user', verb: 'get', func: [limitTok(), limitIP(), getUserInfo] },
+    { path: '/user', verb: 'del', func: [limitTok(10, 0.1), limitIP(10, 0.1), deleteUser] },
+    { path: '/user/:userid', verb: 'get', func: [limitTok(), limitIP(), getUserInfo] },
+    { path: '/user/:userid', verb: 'del', func: [limitTok(10, 0.1), limitIP(10, 0.1), deleteUser] },
+    { path: '/login', verb: 'post', func: [limitTok(3, 0.1), limitIP(3, 0.1), restify.authorizationParser(), login ] },
+    { path: '/login', verb: 'get', func: [limitTok(5, 0.1), limitIP(5, 0.1), refreshSession] },
+    { path: '/serverlogin', verb: 'post', func: [limitTok(3, 0.1), limitIP(3, 0.1), serverLogin] },
     { path: '/token/:token', verb: 'get', func: [requireServerToken, serverCheckToken] },
-    { path: '/logout', verb: 'post', func: logout },
-    { path: '/private', verb: 'get', func: anonymousIdHashPair },
+    { path: '/logout', verb: 'post', func: [limitTok(5, 0.1), limitIP(5, 0.1), logout] },
+    { path: '/private', verb: 'get', func: [limitTok(), limitIP(), anonymousIdHashPair] },
     { path: '/private/:userid/:key/', verbs: ['get', 'post', 'del', 'put'],
       func: [requireServerToken, manageIdHashPair] }
   ];

--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -94,8 +94,9 @@ module.exports = function (envConfig, userService) {
   };
 
   var unpackSessionToken = function (token) {
+    var unpacked;
     try {
-      var unpacked = jwt.decode(token, secret);
+      unpacked = jwt.decode(token, secret);
     } catch (e) {
       // if the decrypt fails this will throw, so we can just return nothing and move on
       return null;

--- a/test/test_user_api_unit.js
+++ b/test/test_user_api_unit.js
@@ -835,4 +835,20 @@ describe('userapi', function () {
     });
 
   });
+
+  describe('GET /testthrottle', function () {
+
+    it('should respond with 200', function (done) {
+      supertest.get('/testthrottle').expect(200).end(done);
+    });
+    it('should respond with 200', function (done) {
+      supertest.get('/testthrottle').expect(200).end(done);
+    });
+    it('should respond with 200', function (done) {
+      supertest.get('/testthrottle').expect(200).end(done);
+    });
+    it('should respond with 429', function (done) {
+      supertest.get('/testthrottle').expect(429).end(done);
+    });
+  });
 });

--- a/test/test_user_api_unit.js
+++ b/test/test_user_api_unit.js
@@ -836,19 +836,19 @@ describe('userapi', function () {
 
   });
 
-  describe('GET /testthrottle', function () {
+  describe('GET /test/throttle', function () {
 
     it('should respond with 200', function (done) {
-      supertest.get('/testthrottle').expect(200).end(done);
+      supertest.get('/test/throttle').expect(200).end(done);
     });
     it('should respond with 200', function (done) {
-      supertest.get('/testthrottle').expect(200).end(done);
+      supertest.get('/test/throttle').expect(200).end(done);
     });
     it('should respond with 200', function (done) {
-      supertest.get('/testthrottle').expect(200).end(done);
+      supertest.get('/test/throttle').expect(200).end(done);
     });
     it('should respond with 429', function (done) {
-      supertest.get('/testthrottle').expect(429).end(done);
+      supertest.get('/test/throttle').expect(429).end(done);
     });
   });
 });


### PR DESCRIPTION
This is an experiment to add request throttling to the user-api. It's not really perfect, but I wanted to put it out as an example for discussion.

In particular, I want @cheddar to look at it to see how he feels about doing this in styx instead. I could imagine throttling at the public route level rather than at the individual API level. It would probably mean additional information on burst/rate added to the route setup in styx.
