### PR TITLE
Kjq/email userinfo

### DIFF
--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -217,8 +217,14 @@ module.exports = function (envConfig, userService) {
     if (sessiontoken) {
       var data = unpackSessionToken(sessiontoken);
       var uid = req.params.userid || data.usr; // userid if specified, current user if not
+      var searchparms = {};
+      if (data.svr === 'yes') { // we have a server token, so do a general search
+        searchparms.user = uid;
+      } else {  // if it's a user token, only a user search is permitted
+        searchparms.userid = uid;
+      }
       userService.getUser(
-        { userid: uid },
+        searchparms,
         function (err, result) {
           if (result.statuscode == 200) {
             // something was found, let's make sure it's unique
@@ -228,7 +234,6 @@ module.exports = function (envConfig, userService) {
               res.send(result.statuscode, result.detail[0]);
             }
           } else {
-            log.info('should never get here! in getUserInfo method');
             res.send(result.statuscode, result.msg);
           }
           return next();

--- a/test/test_user_api_unit.js
+++ b/test/test_user_api_unit.js
@@ -248,6 +248,40 @@ describe('userapi', function () {
       });
     });
 
+    describe('GET /user/:myuserid while logged in', function () {
+
+      it('should respond with 200 and user info', function (done) {
+        supertest
+          .get('/user/' + user.userid)
+          .set('X-Tidepool-Session-Token', sessionToken)
+          .expect(200)
+          .end(function (err, obj) {
+            if (err) return done(err);
+            expect(obj.res.body.username).to.exist;
+            expect(obj.res.body.username).to.equal(user.username);
+            expect(obj.res.body.emails).to.exist;
+            expect(obj.res.body.emails[0]).to.equal(user.emails[0]);
+            expect(obj.res.body.userid).to.exist;
+            expect(obj.res.body.userid).to.equal(user.userid);
+            done();
+          });
+      });
+    });
+
+    describe('GET /user/:email while logged in', function () {
+
+      it('should respond with 204', function (done) {
+        supertest
+          .get('/user/' + user.emails[0])
+          .set('X-Tidepool-Session-Token', sessionToken)
+          .expect(204)
+          .end(function (err, obj) {
+            done();
+          });
+      });
+    });
+
+
     describe('GET /login for logged in user', function () {
 
       it('should return 200 with a new token and the user ID', function (done) {
@@ -462,6 +496,26 @@ describe('userapi', function () {
       it('should respond with 200 and user info', function (done) {
         supertest
           .get('/user/' + user.userid)
+          .set('X-Tidepool-Session-Token', serverToken)
+          .expect(200)
+          .end(function (err, obj) {
+            if (err) return done(err);
+            expect(obj.res.body.username).to.exist;
+            expect(obj.res.body.username).to.equal(user.username);
+            expect(obj.res.body.emails).to.exist;
+            expect(obj.res.body.emails[0]).to.equal(user.emails[0]);
+            expect(obj.res.body.userid).to.exist;
+            expect(obj.res.body.userid).to.equal(user.userid);
+            done();
+          });
+      });
+    });
+
+    describe('GET /user/:email as a server', function () {
+
+      it('should respond with 200 and user info', function (done) {
+        supertest
+          .get('/user/' + user.emails[0])
           .set('X-Tidepool-Session-Token', serverToken)
           .expect(200)
           .end(function (err, obj) {


### PR DESCRIPTION
Modify the getUserInfo (the /user query) so that it can take an email address or username as well as the userid, but only if it's a server that's asking. This will allow servers to query based on an email address.
