### PR TITLE
Support a long-duration (30 days) token request

### DIFF
--- a/env.js
+++ b/env.js
@@ -83,6 +83,11 @@ module.exports = (function() {
     throw new Error('Must specify SALT_DEPLOY in your environment.');
   }
 
+  // This is the key to use if you want to create a longterm token. 
+  // It's ok for this to be missing; if not here, then you can't 
+  // create a longerm token.
+  env.longtermkey = process.env.LONGTERM_KEY;
+
   // The host to contact for discovery
   env.discovery = {
     // The host to connect to for discovery

--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -78,23 +78,29 @@ module.exports = function (envConfig, userService) {
   // period of time
   // we need the ability to limit app usage to certain groups; it probably has to
   // do with matching metadata in an app token to metadata on a user
-  var getSessionToken = function (userid, isServer) {
+  var getSessionToken = function (userid, duration, isServer) {
     if (!userid) {
       return null;
     }
 
     // duration is in seconds
-    var duration = 60 * 60 * 1; // token lasts for 1 hour
-    // unless you're a server
-    if (isServer) {
-      duration = 60 * 60 * 24;
-    } // server tokens last a day
+    if (duration == null) {
+      // if duration wasn't specified
+      duration = 60 * 60 * 1; // token lasts for 1 hour
+      // unless you're a server
+      if (isServer) {
+        duration = 60 * 60 * 24;
+      } // server tokens last a day
+    }
+    // NOTE: This log call is required for testing!
+    log.info('Creating token with duration of %d seconds.', duration);
     // someday we'll allow configurable durations based on user id
     if (duration > 0) {
       var sessiontoken = jwt.encode({
         usr: userid,
         exp: moment().add('seconds', duration).valueOf(),
-        svr: isServer ? 'yes' : 'no'
+        svr: isServer ? 'yes' : 'no',
+        dur: duration
       }, secret);
 
       return sessiontoken;
@@ -209,7 +215,7 @@ module.exports = function (envConfig, userService) {
         }
       }
       if (result.statuscode == 201) {
-        var sessiontoken = getSessionToken(result.detail.userid);
+        var sessiontoken = getSessionToken(result.detail.userid, req.tokenduration);
         upsertToken(sessiontoken, function (err, stored) {
           res.header('x-tidepool-session-token', sessiontoken);
           res.send(result.statuscode, result.detail);
@@ -350,7 +356,7 @@ module.exports = function (envConfig, userService) {
           res.send(401, 'login failed');
         } else {
           // we're good, create a token
-          var sessiontoken = getSessionToken(result.detail[0].userid);
+          var sessiontoken = getSessionToken(result.detail[0].userid, req.tokenduration);
           upsertToken(sessiontoken, function (err, stored) {
             res.header('x-tidepool-session-token', sessiontoken);
             res.send(result.statuscode, _.pick(result.detail[0], 'userid', 'username', 'emails'));
@@ -387,7 +393,7 @@ module.exports = function (envConfig, userService) {
 
     if (pw === envConfig.serverSecret) {
       // we're good, create a token
-      var sessiontoken = getSessionToken(server, true);
+      var sessiontoken = getSessionToken(server, req.tokenduration, true);
       upsertToken(sessiontoken, function (err, stored) {
         res.header('x-tidepool-session-token', sessiontoken);
         res.send(200, 'machine login');
@@ -407,7 +413,14 @@ module.exports = function (envConfig, userService) {
         var response = {
           userid: result.data.usr
         };
-        var newtoken = getSessionToken(result.data.usr, (result.data.svr === 'yes'));
+        // if a usr token is long-duration, it's not renewable, so just return it
+        if (result.data.svr !== 'yes' && result.data.dur > 60 * 60 * 2) {
+          res.header('x-tidepool-session-token', result.token);
+          res.send(200, response);
+          return next();
+        }
+
+        var newtoken = getSessionToken(result.data.usr, req.tokenduration, (result.data.svr === 'yes'));
         upsertToken(newtoken, result.token, function (err, stored) {
           res.header('x-tidepool-session-token', newtoken);
           res.send(200, response);
@@ -418,6 +431,15 @@ module.exports = function (envConfig, userService) {
       }
       return next();
     });
+  };
+
+  // this is middleware designed to check that the longterm key, if supplied,
+  // is valid. If valid, req.tokenduration is set to a duration value in sec
+  var validateLongterm = function (req, res, next) {
+    if (req.params.longtermkey != null && req.params.longtermkey === envConfig.longtermkey) {
+      req.tokenduration = 30 * 24 * 60 * 60; // 30 days
+    }
+    return next();
   };
 
   // this is middleware designed to check that the token supplied is a server token
@@ -564,6 +586,7 @@ module.exports = function (envConfig, userService) {
     { path: '/user/:userid', verb: 'put', func: updateUser },
     { path: '/login', verb: 'post', func: [ restify.authorizationParser(), login ] },
     { path: '/login', verb: 'get', func: refreshSession },
+    { path: '/login/:longtermkey', verb: 'post', func: [ restify.authorizationParser(), validateLongterm, login ] },
     { path: '/serverlogin', verb: 'post', func: serverLogin },
     { path: '/token/:token', verb: 'get', func: [requireServerToken, serverCheckToken] },
     { path: '/logout', verb: 'post', func: logout },


### PR DESCRIPTION
This is the code to let the user-api support a token request for a 30-day token which can support mobile use. All user tokens of longer than 2 hours are considered nonrenewable (the renew call simply returns the same token). Server tokens are always renewable.

It has the side effect of making tokens longer. 

This PR will be followed by one to move the token data into a database and to use short opaque token hashes instead.

@cheddar if you can take a peek, i'd appreciate it.
