### PR TITLE
User delete flag

### DIFF
--- a/env.js
+++ b/env.js
@@ -102,5 +102,9 @@ module.exports = (function() {
     }
   }
 
+  //The time window for a delete flag. Used as a multiplier to mark the date an account will need to be deleted on.
+  // The multiplier is in days.
+  env.deleteWindow = config.fromEnvironment('DELETE_TIME_WINDOW', 14);
+
   return env;
 })();

--- a/env.js
+++ b/env.js
@@ -107,5 +107,9 @@ module.exports = (function() {
   // The local host to publish to discovery
   env.publishHost = config.fromEnvironment('PUBLISH_HOST');
 
+  //The time window for a delete flag. Used as a multiplier to mark the date an account will need to be deleted on.
+  // The multiplier is in days.
+  env.deleteWindow = config.fromEnvironment('DELETE_TIME_WINDOW', 14);
+
   return env;
 })();

--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -321,6 +321,26 @@ module.exports = function (envConfig, userService) {
     if (pw == null || uid == null) {
       res.send(403);
       return next();
+    } else {
+      var userData = { 'userid': uid, 'password': pw };
+      userService.getUser(userData, function(err, result) {
+        if(result.statuscode == 200) {
+          // so we got something back - let's do some additional validation
+          if (result.detail.length != 1) {
+            //we got more than one back, gotta throw that out
+            log.info('number of users returned from the user search is wrong.');
+            res.send(401, 'User search failed');
+          } else {
+            log.info("correct user found.");
+          }
+        } else if(result.statuscode == 204) {
+          //turns out the entered password didn't match the user's password. rejected.
+          log.info('password entered did not match users stored password');
+          res.send(403, 'authentication failed');
+        } else {
+          res.send(result.statuscode, result.msg);
+        }
+      });
     }
 
     switch (req.method) {

--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -326,7 +326,7 @@ module.exports = function (envConfig, userService) {
             log.info('number of users returned from the user search is wrong.');
             res.send(401, 'User search failed');
           } else {
-            log.info("correct user found.");
+            log.info('correct user found.');
           }
         } else if(result.statuscode == 204) {
           //turns out the entered password didn't match the user's password. rejected.

--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -302,12 +302,10 @@ module.exports = function (envConfig, userService) {
     var tokenData = unpackSessionToken(sessiontoken);
     // we can only set a delete flag if we're a server
     var uid = null;
-    if (tokenData.srv === 'yes') {
-      log.info('server');
+    if (tokenData.svr === 'yes') {
       uid = req.params.userid;
       postWithUser(uid, 'setdeleteflag', {server: true}, sessiontoken);
     } else {
-      log.info('non-server');
       uid = tokenData.usr;
       postThisUser('setdeleteflag', {server: false}, sessiontoken);
     }
@@ -319,7 +317,7 @@ module.exports = function (envConfig, userService) {
     if (pw == null) {
       res.send(403, 'No password present.');
     } else {
-      var userData = { 'username': uid, 'password': pw };
+      var userData = { 'userid' : uid, 'password': pw};
       userService.getUser(userData, function(err, result) {
         if(result.statuscode == 200) {
           // so we got something back - let's do some additional validation

--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -340,6 +340,8 @@ module.exports = function (envConfig, userService) {
     } else {
       uid = tokenData.usr;
       postThisUser('setdeleteflag', {server: false}, sessiontoken);
+      res.send(401, 'Unauthorized'); //no server token, no delete.
+      return next();
     }
 
     // we need to require and verify the password since a user should be able to set only their own delete flag

--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -320,9 +320,8 @@ module.exports = function (envConfig, userService) {
       return next();
     }
 
-    // TODO: What HTTP methods do we want to utilize here? The POST/PUT scenario is kludgey at best.
     switch (req.method) {
-      case 'POST':
+      case 'DELETE':
         // TODO: Sundial wrapper or moment.js for date? It'll need to stay uniform across the API.
         userService.updateUser(uid, {deleteflag: new Date().toISOString()}, function (err, result) {
           if (err != null) {
@@ -330,13 +329,13 @@ module.exports = function (envConfig, userService) {
             res.send(err.statuscode, err);
           } else {
             log.info('Set delete flag', result);
-            res.send(result.statuscode, result.detail);
+            res.send(202, result.detail);
           }
           return next();
         });
         break;
 
-      case 'PUT':
+      case 'POST':
         userService.updateUser(uid, {deleteflag: ''}, function (err, result) {
           if (err != null) {
             log.error('Unable to unset delete flag', err);
@@ -659,7 +658,7 @@ module.exports = function (envConfig, userService) {
     { path: '/private', verb: 'get', func: anonymousIdHashPair },
     { path: '/private/:userid/:key/', verbs: ['get', 'post', 'del', 'put'],
       func: [requireServerToken, manageIdHashPair] },
-    { path: '/user/:userid/deleteflag', verbs: ['post', 'put'], func: setDeleteFlag}
+    { path: '/user/:userid/deleteflag', verbs: ['post', 'del'], func: setDeleteFlag}
   ];
 
   // helper function to set up one endpoint for one verb

--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -307,12 +307,10 @@ module.exports = function (envConfig, userService) {
     var tokenData = unpackSessionToken(sessiontoken);
     // we can only set a delete flag if we're a server
     var uid = null;
-    if (tokenData.srv === 'yes') {
-      log.info('server');
+    if (tokenData.svr === 'yes') {
       uid = req.params.userid;
       postWithUser(uid, 'setdeleteflag', {server: true}, sessiontoken);
     } else {
-      log.info('non-server');
       uid = tokenData.usr;
       postThisUser('setdeleteflag', {server: false}, sessiontoken);
     }
@@ -324,7 +322,7 @@ module.exports = function (envConfig, userService) {
     if (pw == null) {
       res.send(403, 'No password present.');
     } else {
-      var userData = { 'username': uid, 'password': pw };
+      var userData = { 'userid' : uid, 'password': pw};
       userService.getUser(userData, function(err, result) {
         if(result.statuscode == 200) {
           // so we got something back - let's do some additional validation

--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -332,7 +332,12 @@ module.exports = function (envConfig, userService) {
           //turns out the entered password didn't match the user's password. rejected.
           log.info('password entered did not match users stored password');
           res.send(403, 'authentication failed');
+        } else if(result.statuscode == 500) {
+          // if nothing was returned for the user/pw combination, something went wrong and it's a forbidden return
+          log.info('no users returned from query');
+          res.send(403, 'no users returned from query');
         } else {
+          // general return statement, although i don't think it will ever execute
           res.send(result.statuscode, result.msg);
         }
       });

--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -29,6 +29,9 @@ module.exports = function (envConfig, userService) {
   // tell it what file we're using (or just supply a logger)
   var log = envConfig.logger || require('./log.js').createLogger(envConfig.logName);
 
+  // let's grab the 'purgatory' period for a delete flag
+  var deleteWindowTime = envConfig.deleteWindow;
+
   // helpful utilities
   var util = require('util');
   var restify = require('restify');
@@ -323,7 +326,7 @@ module.exports = function (envConfig, userService) {
     switch (req.method) {
       case 'DELETE':
         // TODO: Sundial wrapper or moment.js for date? It'll need to stay uniform across the API.
-        userService.updateUser(uid, {deleteflag: new Date().toISOString()}, function (err, result) {
+        userService.updateUser(uid, {deleteflag: moment().utc().add('days', deleteWindowTime)}, function (err, result) {
           if (err != null) {
             log.error('Unable to set delete flag', err);
             res.send(err.statuscode, err);

--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -315,9 +315,8 @@ module.exports = function (envConfig, userService) {
       return next();
     }
 
-    // TODO: What HTTP methods do we want to utilize here? The POST/PUT scenario is kludgey at best.
     switch (req.method) {
-      case 'POST':
+      case 'DELETE':
         // TODO: Sundial wrapper or moment.js for date? It'll need to stay uniform across the API.
         userService.updateUser(uid, {deleteflag: new Date().toISOString()}, function (err, result) {
           if (err != null) {
@@ -325,13 +324,13 @@ module.exports = function (envConfig, userService) {
             res.send(err.statuscode, err);
           } else {
             log.info('Set delete flag', result);
-            res.send(result.statuscode, result.detail);
+            res.send(202, result.detail);
           }
           return next();
         });
         break;
 
-      case 'PUT':
+      case 'POST':
         userService.updateUser(uid, {deleteflag: ''}, function (err, result) {
           if (err != null) {
             log.error('Unable to unset delete flag', err);
@@ -636,7 +635,7 @@ module.exports = function (envConfig, userService) {
     { path: '/private', verb: 'get', func: anonymousIdHashPair },
     { path: '/private/:userid/:key/', verbs: ['get', 'post', 'del', 'put'],
       func: [requireServerToken, manageIdHashPair] },
-    { path: '/user/:userid/deleteflag', verbs: ['post', 'put'], func: setDeleteFlag}
+    { path: '/user/:userid/deleteflag', verbs: ['post', 'del'], func: setDeleteFlag}
   ];
 
   // helper function to set up one endpoint for one verb

--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -291,7 +291,7 @@ module.exports = function (envConfig, userService) {
   };
 
   var setDeleteFlag = function (req, res, next) {
-    var sessiontoken = req.headers['x-tidepool-session-token']
+    var sessiontoken = req.headers['x-tidepool-session-token'];
     if (sessiontoken == null) {
       res.send(401, 'Unauthorized'); // not authorized to make changes without a session
     }
@@ -300,8 +300,8 @@ module.exports = function (envConfig, userService) {
     // we can only set a delete flag if we're a server
     // we need to require the password since a user should be able to set only their own delete flag
     var uid = null;
-    if (tkenData.srv === 'yes') {
-      uid = req.params.userid
+    if (tokenData.srv === 'yes') {
+      uid = req.params.userid;
       postWithUser(uid, 'setdeleteflag', {server: true}, sessiontoken);
     } else {
       uid = tokenData.usr;
@@ -316,7 +316,7 @@ module.exports = function (envConfig, userService) {
     }
     switch (req.method) {
       case 'POST':
-        userService.updateUser(uid, {deleteflag: new Date(UTC).toISOString()}, function (err, result) {
+        userService.updateUser(uid, {deleteflag: new Date().toISOString()}, function (err, result) {
           if (err != null) {
             log.error('Unable to set delete flag', err);
             res.send(err.statuscode, err);

--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -290,6 +290,63 @@ module.exports = function (envConfig, userService) {
     return next();
   };
 
+  var setDeleteFlag = function (req, res, next) {
+    var sessiontoken = req.headers['x-tidepool-session-token']
+    if (sessiontoken == null) {
+      res.send(401, 'Unauthorized'); // not authorized to make changes without a session
+    }
+
+    var tokenData = unpackSessionToken(sessiontoken);
+    // we can only set a delete flag if we're a server
+    // we need to require the password since a user should be able to set only their own delete flag
+    var uid = null;
+    if (tkenData.srv === 'yes') {
+      uid = req.params.userid
+      postWithUser(uid, 'setdeleteflag', {server: true}, sessiontoken);
+    } else {
+      uid = tokenData.usr;
+      postThisUser('deleteuser', {server: false}, sessiontoken);
+    }
+
+    // let's verify the user's password
+    var pw = req.params.password;
+    if (pw == null || uid == null) {
+      res.send(403);
+      return next();
+    }
+    switch (req.method) {
+      case 'POST':
+        userService.updateUser(uid, {deleteflag: new Date(UTC).toISOString()}, function (err, result) {
+          if (err != null) {
+            log.error('Unable to set delete flag', err);
+            res.send(err.statuscode, err);
+          } else {
+            log.info('Set delete flag', result);
+            res.send(result.statuscode, result.detail);
+          }
+          return next();
+        });
+        break;
+
+      case 'PUT':
+        userService.updateUser(uid, {deleteflag: ''}, function (err, result) {
+          if (err != null) {
+            log.error('Unable to unset delete flag', err);
+            res.send(err.statuscode, err);
+          } else {
+            log.info('Unset delete flag', result);
+            res.send(204, result.detail);
+          }
+          return next();
+        });
+        break;
+
+      default:
+        log.warn('Bad HTTP method used', req.method);
+        res.send(405); //sending 405 - request method not supported by resource
+    }
+  };
+
   var deleteUser = function (req, res, next) {
     var sessiontoken = req.headers['x-tidepool-session-token'];
     if (sessiontoken == null) {
@@ -575,7 +632,8 @@ module.exports = function (envConfig, userService) {
     { path: '/logout', verb: 'post', func: logout },
     { path: '/private', verb: 'get', func: anonymousIdHashPair },
     { path: '/private/:userid/:key/', verbs: ['get', 'post', 'del', 'put'],
-      func: [requireServerToken, manageIdHashPair] }
+      func: [requireServerToken, manageIdHashPair] },
+    { path: '/user/:userid/deleteflag', verbs: ['post, put'], func: setDeleteFlag}
   ];
 
   // helper function to set up one endpoint for one verb

--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -298,6 +298,26 @@ module.exports = function (envConfig, userService) {
     return next();
   };
 
+  /**
+   * Function responsible for setting the delete flag of a user. The flag is set based on a multiplier present in the
+   * environment configuration object. The `deleteflag` attribute will be added to the user's data and will contain the
+   * date/time stamp of the date that the user's account will be deleted.
+   *
+   * In order to utilize this function, the user must resubmit their password with the request for additional verification.
+   *
+   * DELETE /user/:userid/deleteflag - set's the user's delete flag to the current time and date plus 14 days. Repeated
+   *  calls with this method/path combination will reset the user's delete flag value to the current date + 14 days.
+   *
+   * POST /user/:userid/deleteflag - removes the value from the user's `deleteflag` attribute, effectively unsetting the
+   *  delete flag on the user's account.
+   *
+   * @param req - the inbound request. should contain the user's password as well as the x-tidepool-session-token of the server
+   * @param res - the response object returned. status codes vary depending on the result of the function. potential
+   *  responses include 401 for missing session token, 405 for an unsupported http method, 403 for missing/incorrect
+   *  password or failed user search, 202 for a successful `deleteflag` set, or 204 for a successful un-set.
+   * @param next - callback function to execute after setDeleteFlag returns
+   * @returns {*}
+   */
   var setDeleteFlag = function (req, res, next) {
     var sessiontoken = req.headers['x-tidepool-session-token'];
     if (sessiontoken == null) {

--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -297,6 +297,7 @@ module.exports = function (envConfig, userService) {
     var sessiontoken = req.headers['x-tidepool-session-token'];
     if (sessiontoken == null) {
       res.send(401, 'Unauthorized'); // not authorized to make changes without a session
+      return next();
     }
 
     var tokenData = unpackSessionToken(sessiontoken);
@@ -312,10 +313,10 @@ module.exports = function (envConfig, userService) {
 
     // we need to require and verify the password since a user should be able to set only their own delete flag
     var pw = req.params.password;
-    var user = null;
 
     if (pw == null) {
       res.send(403, 'No password present.');
+      return next();
     } else {
       var userData = { 'userid' : uid, 'password': pw};
       userService.getUser(userData, function(err, result) {
@@ -325,10 +326,49 @@ module.exports = function (envConfig, userService) {
             //we got more than one back, gotta throw that out
             log.info('number of users returned from the user search is wrong.');
             res.send(401, 'User search failed');
+            return next();
           } else {
             log.info(result.detail);
             log.info('correct user found.');
-            user = result.detail;
+
+            switch (req.method) {
+              case 'DELETE':
+                log.info('setting delete flag for user', uid);
+
+                var timedate = moment().utc().add('days', deleteWindowTime).toISOString();
+                log.info('delete window timing is', deleteWindowTime);
+                log.info('setting timedate for delete as ', timedate);
+                userService.updateUser(uid, {deleteflag: timedate}, function (err, result) {
+                  if (err !== null) {
+                    log.error('Unable to set delete flag', err);
+                    res.send(err.statuscode, err);
+                  } else {
+                    log.info('Set delete flag', result);
+                    res.send(202, result.detail);
+                  }
+                  return next();
+                });
+                break;
+
+              case 'POST':
+                log.info('unsetting delete flag for user', uid);
+                userService.updateUser(uid, {deleteflag: ''}, function (err, result) {
+                  if (err !== null) {
+                    log.error('Unable to unset delete flag', err);
+                    res.send(err.statuscode, err);
+                  } else {
+                    log.info('Unset delete flag', result);
+                    res.send(204, result.detail);
+                  }
+                  return next();
+                });
+                break;
+
+              default:
+                log.warn('Bad HTTP method used', req.method);
+                res.send(405); //sending 405 - request method not supported by resource
+                return next();
+            }
           }
         } else if(result.statuscode == 204) {
           //turns out the entered password didn't match the user's password. rejected.
@@ -342,47 +382,8 @@ module.exports = function (envConfig, userService) {
           // general return statement, although i don't think it will ever execute
           res.send(result.statuscode, result.msg);
         }
+        return next();
       });
-    }
-
-    if(user != null) {
-      switch (req.method) {
-        case 'DELETE':
-          log.info('setting delete flag for user', user.username);
-          var timedate = moment().utc().add('days', deleteWindowTime).toISOString();
-          log.info('setting timedate for delete as ', timedate);
-          userService.updateUser(user, {deleteflag: timedate}, function (err, result) {
-            if (err !== null) {
-              log.error('Unable to set delete flag', err);
-              res.send(err.statuscode, err);
-            } else {
-              log.info('Set delete flag', result);
-              res.send(202, result.detail);
-            }
-            return next();
-          });
-          break;
-
-        case 'POST':
-          log.info('unsetting delete flag for user', user.username);
-          userService.updateUser(user, {deleteflag: ''}, function (err, result) {
-            if (err !== null) {
-              log.error('Unable to unset delete flag', err);
-              res.send(err.statuscode, err);
-            } else {
-              log.info('Unset delete flag', result);
-              res.send(204, result.detail);
-            }
-            return next();
-          });
-          break;
-
-        default:
-          log.warn('Bad HTTP method used', req.method);
-          res.send(405); //sending 405 - request method not supported by resource
-      }
-    } else {
-      log.info('User object contains null value.');
     }
   };
 

--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -296,7 +296,7 @@ module.exports = function (envConfig, userService) {
   };
 
   var setDeleteFlag = function (req, res, next) {
-    var sessiontoken = req.headers['x-tidepool-session-token']
+    var sessiontoken = req.headers['x-tidepool-session-token'];
     if (sessiontoken == null) {
       res.send(401, 'Unauthorized'); // not authorized to make changes without a session
     }
@@ -305,8 +305,8 @@ module.exports = function (envConfig, userService) {
     // we can only set a delete flag if we're a server
     // we need to require the password since a user should be able to set only their own delete flag
     var uid = null;
-    if (tkenData.srv === 'yes') {
-      uid = req.params.userid
+    if (tokenData.srv === 'yes') {
+      uid = req.params.userid;
       postWithUser(uid, 'setdeleteflag', {server: true}, sessiontoken);
     } else {
       uid = tokenData.usr;
@@ -321,7 +321,7 @@ module.exports = function (envConfig, userService) {
     }
     switch (req.method) {
       case 'POST':
-        userService.updateUser(uid, {deleteflag: new Date(UTC).toISOString()}, function (err, result) {
+        userService.updateUser(uid, {deleteflag: new Date().toISOString()}, function (err, result) {
           if (err != null) {
             log.error('Unable to set delete flag', err);
             res.send(err.statuscode, err);

--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -331,7 +331,7 @@ module.exports = function (envConfig, userService) {
             log.info('number of users returned from the user search is wrong.');
             res.send(401, 'User search failed');
           } else {
-            log.info("correct user found.");
+            log.info('correct user found.');
           }
         } else if(result.statuscode == 204) {
           //turns out the entered password didn't match the user's password. rejected.

--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -337,7 +337,12 @@ module.exports = function (envConfig, userService) {
           //turns out the entered password didn't match the user's password. rejected.
           log.info('password entered did not match users stored password');
           res.send(403, 'authentication failed');
+        } else if(result.statuscode == 500) {
+          // if nothing was returned for the user/pw combination, something went wrong and it's a forbidden return
+          log.info('no users returned from query');
+          res.send(403, 'no users returned from query');
         } else {
+          // general return statement, although i don't think it will ever execute
           res.send(result.statuscode, result.msg);
         }
       });

--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -302,6 +302,7 @@ module.exports = function (envConfig, userService) {
     var sessiontoken = req.headers['x-tidepool-session-token'];
     if (sessiontoken == null) {
       res.send(401, 'Unauthorized'); // not authorized to make changes without a session
+      return next();
     }
 
     var tokenData = unpackSessionToken(sessiontoken);
@@ -317,10 +318,10 @@ module.exports = function (envConfig, userService) {
 
     // we need to require and verify the password since a user should be able to set only their own delete flag
     var pw = req.params.password;
-    var user = null;
 
     if (pw == null) {
       res.send(403, 'No password present.');
+      return next();
     } else {
       var userData = { 'userid' : uid, 'password': pw};
       userService.getUser(userData, function(err, result) {
@@ -330,10 +331,49 @@ module.exports = function (envConfig, userService) {
             //we got more than one back, gotta throw that out
             log.info('number of users returned from the user search is wrong.');
             res.send(401, 'User search failed');
+            return next();
           } else {
             log.info(result.detail);
             log.info('correct user found.');
-            user = result.detail;
+
+            switch (req.method) {
+              case 'DELETE':
+                log.info('setting delete flag for user', uid);
+
+                var timedate = moment().utc().add('days', deleteWindowTime).toISOString();
+                log.info('delete window timing is', deleteWindowTime);
+                log.info('setting timedate for delete as ', timedate);
+                userService.updateUser(uid, {deleteflag: timedate}, function (err, result) {
+                  if (err !== null) {
+                    log.error('Unable to set delete flag', err);
+                    res.send(err.statuscode, err);
+                  } else {
+                    log.info('Set delete flag', result);
+                    res.send(202, result.detail);
+                  }
+                  return next();
+                });
+                break;
+
+              case 'POST':
+                log.info('unsetting delete flag for user', uid);
+                userService.updateUser(uid, {deleteflag: ''}, function (err, result) {
+                  if (err !== null) {
+                    log.error('Unable to unset delete flag', err);
+                    res.send(err.statuscode, err);
+                  } else {
+                    log.info('Unset delete flag', result);
+                    res.send(204, result.detail);
+                  }
+                  return next();
+                });
+                break;
+
+              default:
+                log.warn('Bad HTTP method used', req.method);
+                res.send(405); //sending 405 - request method not supported by resource
+                return next();
+            }
           }
         } else if(result.statuscode == 204) {
           //turns out the entered password didn't match the user's password. rejected.
@@ -347,47 +387,8 @@ module.exports = function (envConfig, userService) {
           // general return statement, although i don't think it will ever execute
           res.send(result.statuscode, result.msg);
         }
+        return next();
       });
-    }
-
-    if(user != null) {
-      switch (req.method) {
-        case 'DELETE':
-          log.info('setting delete flag for user', user.username);
-          var timedate = moment().utc().add('days', deleteWindowTime).toISOString();
-          log.info('setting timedate for delete as ', timedate);
-          userService.updateUser(user, {deleteflag: timedate}, function (err, result) {
-            if (err !== null) {
-              log.error('Unable to set delete flag', err);
-              res.send(err.statuscode, err);
-            } else {
-              log.info('Set delete flag', result);
-              res.send(202, result.detail);
-            }
-            return next();
-          });
-          break;
-
-        case 'POST':
-          log.info('unsetting delete flag for user', user.username);
-          userService.updateUser(user, {deleteflag: ''}, function (err, result) {
-            if (err !== null) {
-              log.error('Unable to unset delete flag', err);
-              res.send(err.statuscode, err);
-            } else {
-              log.info('Unset delete flag', result);
-              res.send(204, result.detail);
-            }
-            return next();
-          });
-          break;
-
-        default:
-          log.warn('Bad HTTP method used', req.method);
-          res.send(405); //sending 405 - request method not supported by resource
-      }
-    } else {
-      log.info('User object contains null value.');
     }
   };
 

--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -316,6 +316,26 @@ module.exports = function (envConfig, userService) {
     if (pw == null || uid == null) {
       res.send(403);
       return next();
+    } else {
+      var userData = { 'userid': uid, 'password': pw };
+      userService.getUser(userData, function(err, result) {
+        if(result.statuscode == 200) {
+          // so we got something back - let's do some additional validation
+          if (result.detail.length != 1) {
+            //we got more than one back, gotta throw that out
+            log.info('number of users returned from the user search is wrong.');
+            res.send(401, 'User search failed');
+          } else {
+            log.info("correct user found.");
+          }
+        } else if(result.statuscode == 204) {
+          //turns out the entered password didn't match the user's password. rejected.
+          log.info('password entered did not match users stored password');
+          res.send(403, 'authentication failed');
+        } else {
+          res.send(result.statuscode, result.msg);
+        }
+      });
     }
 
     switch (req.method) {

--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -310,7 +310,7 @@ module.exports = function (envConfig, userService) {
       postWithUser(uid, 'setdeleteflag', {server: true}, sessiontoken);
     } else {
       uid = tokenData.usr;
-      postThisUser('deleteuser', {server: false}, sessiontoken);
+      postThisUser('setdeleteflag', {server: false}, sessiontoken);
     }
 
     // let's verify the user's password
@@ -319,8 +319,11 @@ module.exports = function (envConfig, userService) {
       res.send(403);
       return next();
     }
+
+    // TODO: What HTTP methods do we want to utilize here? The POST/PUT scenario is kludgey at best.
     switch (req.method) {
       case 'POST':
+        // TODO: Sundial wrapper or moment.js for date? It'll need to stay uniform across the API.
         userService.updateUser(uid, {deleteflag: new Date().toISOString()}, function (err, result) {
           if (err != null) {
             log.error('Unable to set delete flag', err);

--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -301,23 +301,25 @@ module.exports = function (envConfig, userService) {
 
     var tokenData = unpackSessionToken(sessiontoken);
     // we can only set a delete flag if we're a server
-    // we need to require the password since a user should be able to set only their own delete flag
     var uid = null;
     if (tokenData.srv === 'yes') {
+      log.info('server');
       uid = req.params.userid;
       postWithUser(uid, 'setdeleteflag', {server: true}, sessiontoken);
     } else {
+      log.info('non-server');
       uid = tokenData.usr;
       postThisUser('setdeleteflag', {server: false}, sessiontoken);
     }
 
-    // let's verify the user's password
+    // we need to require and verify the password since a user should be able to set only their own delete flag
     var pw = req.params.password;
-    if (pw == null || uid == null) {
-      res.send(403);
-      return next();
+    var user = null;
+
+    if (pw == null) {
+      res.send(403, 'No password present.');
     } else {
-      var userData = { 'userid': uid, 'password': pw };
+      var userData = { 'username': uid, 'password': pw };
       userService.getUser(userData, function(err, result) {
         if(result.statuscode == 200) {
           // so we got something back - let's do some additional validation
@@ -326,7 +328,9 @@ module.exports = function (envConfig, userService) {
             log.info('number of users returned from the user search is wrong.');
             res.send(401, 'User search failed');
           } else {
+            log.info(result.detail);
             log.info('correct user found.');
+            user = result.detail;
           }
         } else if(result.statuscode == 204) {
           //turns out the entered password didn't match the user's password. rejected.
@@ -343,37 +347,44 @@ module.exports = function (envConfig, userService) {
       });
     }
 
-    switch (req.method) {
-      case 'DELETE':
-        // TODO: Sundial wrapper or moment.js for date? It'll need to stay uniform across the API.
-        userService.updateUser(uid, {deleteflag: moment().utc().add('days', deleteWindowTime)}, function (err, result) {
-          if (err != null) {
-            log.error('Unable to set delete flag', err);
-            res.send(err.statuscode, err);
-          } else {
-            log.info('Set delete flag', result);
-            res.send(202, result.detail);
-          }
-          return next();
-        });
-        break;
+    if(user != null) {
+      switch (req.method) {
+        case 'DELETE':
+          log.info('setting delete flag for user', user.username);
+          var timedate = moment().utc().add('days', deleteWindowTime).toISOString();
+          log.info('setting timedate for delete as ', timedate);
+          userService.updateUser(user, {deleteflag: timedate}, function (err, result) {
+            if (err !== null) {
+              log.error('Unable to set delete flag', err);
+              res.send(err.statuscode, err);
+            } else {
+              log.info('Set delete flag', result);
+              res.send(202, result.detail);
+            }
+            return next();
+          });
+          break;
 
-      case 'POST':
-        userService.updateUser(uid, {deleteflag: ''}, function (err, result) {
-          if (err != null) {
-            log.error('Unable to unset delete flag', err);
-            res.send(err.statuscode, err);
-          } else {
-            log.info('Unset delete flag', result);
-            res.send(204, result.detail);
-          }
-          return next();
-        });
-        break;
+        case 'POST':
+          log.info('unsetting delete flag for user', user.username);
+          userService.updateUser(user, {deleteflag: ''}, function (err, result) {
+            if (err !== null) {
+              log.error('Unable to unset delete flag', err);
+              res.send(err.statuscode, err);
+            } else {
+              log.info('Unset delete flag', result);
+              res.send(204, result.detail);
+            }
+            return next();
+          });
+          break;
 
-      default:
-        log.warn('Bad HTTP method used', req.method);
-        res.send(405); //sending 405 - request method not supported by resource
+        default:
+          log.warn('Bad HTTP method used', req.method);
+          res.send(405); //sending 405 - request method not supported by resource
+      }
+    } else {
+      log.info('User object contains null value.');
     }
   };
 

--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -633,7 +633,7 @@ module.exports = function (envConfig, userService) {
     { path: '/private', verb: 'get', func: anonymousIdHashPair },
     { path: '/private/:userid/:key/', verbs: ['get', 'post', 'del', 'put'],
       func: [requireServerToken, manageIdHashPair] },
-    { path: '/user/:userid/deleteflag', verbs: ['post, put'], func: setDeleteFlag}
+    { path: '/user/:userid/deleteflag', verbs: ['post', 'put'], func: setDeleteFlag}
   ];
 
   // helper function to set up one endpoint for one verb

--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -306,23 +306,25 @@ module.exports = function (envConfig, userService) {
 
     var tokenData = unpackSessionToken(sessiontoken);
     // we can only set a delete flag if we're a server
-    // we need to require the password since a user should be able to set only their own delete flag
     var uid = null;
     if (tokenData.srv === 'yes') {
+      log.info('server');
       uid = req.params.userid;
       postWithUser(uid, 'setdeleteflag', {server: true}, sessiontoken);
     } else {
+      log.info('non-server');
       uid = tokenData.usr;
       postThisUser('setdeleteflag', {server: false}, sessiontoken);
     }
 
-    // let's verify the user's password
+    // we need to require and verify the password since a user should be able to set only their own delete flag
     var pw = req.params.password;
-    if (pw == null || uid == null) {
-      res.send(403);
-      return next();
+    var user = null;
+
+    if (pw == null) {
+      res.send(403, 'No password present.');
     } else {
-      var userData = { 'userid': uid, 'password': pw };
+      var userData = { 'username': uid, 'password': pw };
       userService.getUser(userData, function(err, result) {
         if(result.statuscode == 200) {
           // so we got something back - let's do some additional validation
@@ -331,7 +333,9 @@ module.exports = function (envConfig, userService) {
             log.info('number of users returned from the user search is wrong.');
             res.send(401, 'User search failed');
           } else {
+            log.info(result.detail);
             log.info('correct user found.');
+            user = result.detail;
           }
         } else if(result.statuscode == 204) {
           //turns out the entered password didn't match the user's password. rejected.
@@ -348,37 +352,44 @@ module.exports = function (envConfig, userService) {
       });
     }
 
-    switch (req.method) {
-      case 'DELETE':
-        // TODO: Sundial wrapper or moment.js for date? It'll need to stay uniform across the API.
-        userService.updateUser(uid, {deleteflag: moment().utc().add('days', deleteWindowTime)}, function (err, result) {
-          if (err != null) {
-            log.error('Unable to set delete flag', err);
-            res.send(err.statuscode, err);
-          } else {
-            log.info('Set delete flag', result);
-            res.send(202, result.detail);
-          }
-          return next();
-        });
-        break;
+    if(user != null) {
+      switch (req.method) {
+        case 'DELETE':
+          log.info('setting delete flag for user', user.username);
+          var timedate = moment().utc().add('days', deleteWindowTime).toISOString();
+          log.info('setting timedate for delete as ', timedate);
+          userService.updateUser(user, {deleteflag: timedate}, function (err, result) {
+            if (err !== null) {
+              log.error('Unable to set delete flag', err);
+              res.send(err.statuscode, err);
+            } else {
+              log.info('Set delete flag', result);
+              res.send(202, result.detail);
+            }
+            return next();
+          });
+          break;
 
-      case 'POST':
-        userService.updateUser(uid, {deleteflag: ''}, function (err, result) {
-          if (err != null) {
-            log.error('Unable to unset delete flag', err);
-            res.send(err.statuscode, err);
-          } else {
-            log.info('Unset delete flag', result);
-            res.send(204, result.detail);
-          }
-          return next();
-        });
-        break;
+        case 'POST':
+          log.info('unsetting delete flag for user', user.username);
+          userService.updateUser(user, {deleteflag: ''}, function (err, result) {
+            if (err !== null) {
+              log.error('Unable to unset delete flag', err);
+              res.send(err.statuscode, err);
+            } else {
+              log.info('Unset delete flag', result);
+              res.send(204, result.detail);
+            }
+            return next();
+          });
+          break;
 
-      default:
-        log.warn('Bad HTTP method used', req.method);
-        res.send(405); //sending 405 - request method not supported by resource
+        default:
+          log.warn('Bad HTTP method used', req.method);
+          res.send(405); //sending 405 - request method not supported by resource
+      }
+    } else {
+      log.info('User object contains null value.');
     }
   };
 

--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -295,6 +295,63 @@ module.exports = function (envConfig, userService) {
     return next();
   };
 
+  var setDeleteFlag = function (req, res, next) {
+    var sessiontoken = req.headers['x-tidepool-session-token']
+    if (sessiontoken == null) {
+      res.send(401, 'Unauthorized'); // not authorized to make changes without a session
+    }
+
+    var tokenData = unpackSessionToken(sessiontoken);
+    // we can only set a delete flag if we're a server
+    // we need to require the password since a user should be able to set only their own delete flag
+    var uid = null;
+    if (tkenData.srv === 'yes') {
+      uid = req.params.userid
+      postWithUser(uid, 'setdeleteflag', {server: true}, sessiontoken);
+    } else {
+      uid = tokenData.usr;
+      postThisUser('deleteuser', {server: false}, sessiontoken);
+    }
+
+    // let's verify the user's password
+    var pw = req.params.password;
+    if (pw == null || uid == null) {
+      res.send(403);
+      return next();
+    }
+    switch (req.method) {
+      case 'POST':
+        userService.updateUser(uid, {deleteflag: new Date(UTC).toISOString()}, function (err, result) {
+          if (err != null) {
+            log.error('Unable to set delete flag', err);
+            res.send(err.statuscode, err);
+          } else {
+            log.info('Set delete flag', result);
+            res.send(result.statuscode, result.detail);
+          }
+          return next();
+        });
+        break;
+
+      case 'PUT':
+        userService.updateUser(uid, {deleteflag: ''}, function (err, result) {
+          if (err != null) {
+            log.error('Unable to unset delete flag', err);
+            res.send(err.statuscode, err);
+          } else {
+            log.info('Unset delete flag', result);
+            res.send(204, result.detail);
+          }
+          return next();
+        });
+        break;
+
+      default:
+        log.warn('Bad HTTP method used', req.method);
+        res.send(405); //sending 405 - request method not supported by resource
+    }
+  };
+
   var deleteUser = function (req, res, next) {
     var sessiontoken = req.headers['x-tidepool-session-token'];
     if (sessiontoken == null) {
@@ -598,7 +655,8 @@ module.exports = function (envConfig, userService) {
     { path: '/logout', verb: 'post', func: logout },
     { path: '/private', verb: 'get', func: anonymousIdHashPair },
     { path: '/private/:userid/:key/', verbs: ['get', 'post', 'del', 'put'],
-      func: [requireServerToken, manageIdHashPair] }
+      func: [requireServerToken, manageIdHashPair] },
+    { path: '/user/:userid/deleteflag', verbs: ['post, put'], func: setDeleteFlag}
   ];
 
   // helper function to set up one endpoint for one verb

--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -293,6 +293,26 @@ module.exports = function (envConfig, userService) {
     return next();
   };
 
+  /**
+   * Function responsible for setting the delete flag of a user. The flag is set based on a multiplier present in the
+   * environment configuration object. The `deleteflag` attribute will be added to the user's data and will contain the
+   * date/time stamp of the date that the user's account will be deleted.
+   *
+   * In order to utilize this function, the user must resubmit their password with the request for additional verification.
+   *
+   * DELETE /user/:userid/deleteflag - set's the user's delete flag to the current time and date plus 14 days. Repeated
+   *  calls with this method/path combination will reset the user's delete flag value to the current date + 14 days.
+   *
+   * POST /user/:userid/deleteflag - removes the value from the user's `deleteflag` attribute, effectively unsetting the
+   *  delete flag on the user's account.
+   *
+   * @param req - the inbound request. should contain the user's password as well as the x-tidepool-session-token of the server
+   * @param res - the response object returned. status codes vary depending on the result of the function. potential
+   *  responses include 401 for missing session token, 405 for an unsupported http method, 403 for missing/incorrect
+   *  password or failed user search, 202 for a successful `deleteflag` set, or 204 for a successful un-set.
+   * @param next - callback function to execute after setDeleteFlag returns
+   * @returns {*}
+   */
   var setDeleteFlag = function (req, res, next) {
     var sessiontoken = req.headers['x-tidepool-session-token'];
     if (sessiontoken == null) {

--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -36,6 +36,9 @@ module.exports = function (envConfig, userService) {
   // tell it what file we're using (or just supply a logger)
   var log = envConfig.logger || require('./log.js').createLogger(envConfig.logName);
 
+  // let's grab the 'purgatory' period for a delete flag
+  var deleteWindowTime = envConfig.deleteWindow;
+
   // helpful utilities
   var _ = require('lodash');
   var moment = require('moment');
@@ -318,7 +321,7 @@ module.exports = function (envConfig, userService) {
     switch (req.method) {
       case 'DELETE':
         // TODO: Sundial wrapper or moment.js for date? It'll need to stay uniform across the API.
-        userService.updateUser(uid, {deleteflag: new Date().toISOString()}, function (err, result) {
+        userService.updateUser(uid, {deleteflag: moment().utc().add('days', deleteWindowTime)}, function (err, result) {
           if (err != null) {
             log.error('Unable to set delete flag', err);
             res.send(err.statuscode, err);

--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -656,7 +656,7 @@ module.exports = function (envConfig, userService) {
     { path: '/private', verb: 'get', func: anonymousIdHashPair },
     { path: '/private/:userid/:key/', verbs: ['get', 'post', 'del', 'put'],
       func: [requireServerToken, manageIdHashPair] },
-    { path: '/user/:userid/deleteflag', verbs: ['post, put'], func: setDeleteFlag}
+    { path: '/user/:userid/deleteflag', verbs: ['post', 'put'], func: setDeleteFlag}
   ];
 
   // helper function to set up one endpoint for one verb

--- a/lib/userapi.js
+++ b/lib/userapi.js
@@ -305,7 +305,7 @@ module.exports = function (envConfig, userService) {
       postWithUser(uid, 'setdeleteflag', {server: true}, sessiontoken);
     } else {
       uid = tokenData.usr;
-      postThisUser('deleteuser', {server: false}, sessiontoken);
+      postThisUser('setdeleteflag', {server: false}, sessiontoken);
     }
 
     // let's verify the user's password
@@ -314,8 +314,11 @@ module.exports = function (envConfig, userService) {
       res.send(403);
       return next();
     }
+
+    // TODO: What HTTP methods do we want to utilize here? The POST/PUT scenario is kludgey at best.
     switch (req.method) {
       case 'POST':
+        // TODO: Sundial wrapper or moment.js for date? It'll need to stay uniform across the API.
         userService.updateUser(uid, {deleteflag: new Date().toISOString()}, function (err, result) {
           if (err != null) {
             log.error('Unable to set delete flag', err);

--- a/test/test_user_api_unit.js
+++ b/test/test_user_api_unit.js
@@ -970,20 +970,20 @@ describe('userapi', function () {
     describe('User delete flag set/unset', function() {
       it('should respond with a 401 if no session token is present', function(done) {
         supertest
-          .delete('/user/'+ user.userid + '/deleteflag')
+          .del('/user/'+ user.userid + '/deleteflag')
           .expect(401, done);
       });
 
       it('should respond with a 403 if the users password is null', function(done) {
         supertest
-          .delete('/user/' + user.userid + '/deleteflag')
+          .del('/user/' + user.userid + '/deleteflag')
           .set('X-Tidepool-Session-Token', serverToken)
           .expect(403, done);
       });
 
       it('should respond with a 403 if the users password is wrong', function(done) {
         supertest
-          .delete('/user/' + user.userid + '/deleteflag')
+          .del('/user/' + user.userid + '/deleteflag')
           .send({password: 'abc1234'})
           .set('X-Tidepool-Session-Token')
           .expect(403)
@@ -992,7 +992,7 @@ describe('userapi', function () {
 
       it('should respond with a 202 when the flag is set', function(done) {
         supertest
-          .delete('/user/' + user.userid + '/deleteflag')
+          .del('/user/' + user.userid + '/deleteflag')
           .send({password: user.password})
           .set('X-Tidepool-Session-Token', serverToken)
           .expect(202)

--- a/test/test_user_api_unit.js
+++ b/test/test_user_api_unit.js
@@ -904,7 +904,6 @@ describe('userapi', function () {
     });
 
     describe('User delete flag set/unset', function() {
-      var workingPw = 'bluebayou';
       it('should respond with a 401 if no session token is present', function(done) {
         supertest
           .del('/user/'+ user.userid + '/deleteflag')

--- a/test/test_user_api_unit.js
+++ b/test/test_user_api_unit.js
@@ -36,10 +36,18 @@ var env = {
   serverSecret: 'sharedMachineSecret',
   longtermkey: 'thelongtermkey',
   logger: {
+<<<<<<< HEAD
     error: savelog,
     warn: savelog,
     info: savelog
   }
+=======
+    error: console.log,
+    warn: console.log,
+    info: console.log
+  },
+  deleteWindow: 14
+>>>>>>> reordered test cases to set delete flag before the user is actually deleted from mongo. reordered (and kind of refactored?) the setDeleteFlag function to be cleaner - could probably use some additional refactoring though.
 };
 
 var dbmongo = require('../lib/db_mongo.js')(env);
@@ -924,50 +932,7 @@ describe('userapi', function () {
 
     });
 
-    describe('POST /logout with valid session token', function () {
-
-      it('should respond with 200 and log out', function (done) {
-        supertest
-          .post('/logout')
-          .set('X-Tidepool-Session-Token', sessionToken)
-          .expect(200)
-          .end(done);
-      });
-
-    });
-
-    describe('DELETE /user/:id for server without password', function () {
-      it('should respond with 403', function (done) {
-        supertest
-          .del('/user/' + user.userid)
-          .set('X-Tidepool-Session-Token', serverToken)
-          .expect(403)
-          .end(done);
-      });
-    });
-
-    describe('DELETE /user/:id for server with bad userid', function () {
-      it('should respond with 403', function (done) {
-        supertest
-          .del('/user/' + 'a123af')
-          .set('X-Tidepool-Session-Token', serverToken)
-          .expect(403)
-          .end(done);
-      });
-    });
-
-    describe('DELETE /user/:id for server with password', function () {
-      it('should respond with 200', function (done) {
-        supertest
-          .del('/user/' + user.userid)
-          .send({password: user.password})
-          .set('X-Tidepool-Session-Token', serverToken)
-          .expect(200)
-          .end(done);
-      });
-    });
-
-    describe('User delete flag set/unset', function() {
+    describe('Test user delete flag set/unset functionality', function() {
       it('should respond with a 401 if no session token is present', function(done) {
         supertest
           .del('/user/'+ user.userid + '/deleteflag')
@@ -1024,6 +989,49 @@ describe('userapi', function () {
           .send({password: user.password})
           .set('X-Tidepool-Session-Token', serverToken)
           .expect(405)
+          .end(done);
+      });
+    });
+
+    describe('POST /logout with valid session token', function () {
+
+      it('should respond with 200 and log out', function (done) {
+        supertest
+          .post('/logout')
+          .set('X-Tidepool-Session-Token', sessionToken)
+          .expect(200)
+          .end(done);
+      });
+
+    });
+
+    describe('DELETE /user/:id for server without password', function () {
+      it('should respond with 403', function (done) {
+        supertest
+          .del('/user/' + user.userid)
+          .set('X-Tidepool-Session-Token', serverToken)
+          .expect(403)
+          .end(done);
+      });
+    });
+
+    describe('DELETE /user/:id for server with bad userid', function () {
+      it('should respond with 403', function (done) {
+        supertest
+          .del('/user/' + 'a123af')
+          .set('X-Tidepool-Session-Token', serverToken)
+          .expect(403)
+          .end(done);
+      });
+    });
+
+    describe('DELETE /user/:id for server with password', function () {
+      it('should respond with 200', function (done) {
+        supertest
+          .del('/user/' + user.userid)
+          .send({password: user.password})
+          .set('X-Tidepool-Session-Token', serverToken)
+          .expect(200)
           .end(done);
       });
     });

--- a/test/test_user_api_unit.js
+++ b/test/test_user_api_unit.js
@@ -903,7 +903,38 @@ describe('userapi', function () {
       });
     });
 
+    describe('User delete flag set/unset', function() {
+      it('should respond with a 401 if no session token is present', function(done) {
+        supertest
+          .post('/user/'+ user.userid + '/deleteflag')
+          .expect(401);
+      });
 
+      it('should respond with a 403 if the users password is null', function(done) {
+        supertest
+          .post('/user/' + user.userid + '/deleteflag')
+          .set('X-Tidepool-Session-Token', serverToken)
+          .expect(403);
+      });
+
+      it('should respond with a 200 when the flag is set', function(done) {
+        supertest
+          .post('/user/' + user.userid + '/deleteflag')
+          .send({password: user.password})
+          .set('X-Tidepool-Session-Token', serverToken)
+          .expect(200)
+          .end(done);
+      });
+
+      it('should respond with a 204 when the flag is unset', function(done) {
+        supertest
+          .put('/user/' + user.userid + '/deleteflag')
+          .send({password: user.password})
+          .set('X-Tidepool-Session-Token')
+          .expect(204)
+          .end(done);
+      });
+    });
 
     describe('POST /logout with valid server token', function () {
 

--- a/test/test_user_api_unit.js
+++ b/test/test_user_api_unit.js
@@ -970,32 +970,59 @@ describe('userapi', function () {
     describe('User delete flag set/unset', function() {
       it('should respond with a 401 if no session token is present', function(done) {
         supertest
-          .post('/user/'+ user.userid + '/deleteflag')
+          .delete('/user/'+ user.userid + '/deleteflag')
           .expect(401, done);
       });
 
       it('should respond with a 403 if the users password is null', function(done) {
         supertest
-          .post('/user/' + user.userid + '/deleteflag')
+          .delete('/user/' + user.userid + '/deleteflag')
           .set('X-Tidepool-Session-Token', serverToken)
           .expect(403, done);
       });
 
-      it('should respond with a 200 when the flag is set', function(done) {
+      it('should respond with a 403 if the users password is wrong', function(done) {
         supertest
-          .post('/user/' + user.userid + '/deleteflag')
+          .delete('/user/' + user.userid + '/deleteflag')
+          .send({password: 'abc1234'})
+          .set('X-Tidepool-Session-Token')
+          .expect(403)
+          .end(done);
+      });
+
+      it('should respond with a 202 when the flag is set', function(done) {
+        supertest
+          .delete('/user/' + user.userid + '/deleteflag')
           .send({password: user.password})
           .set('X-Tidepool-Session-Token', serverToken)
-          .expect(200)
+          .expect(202)
           .end(done);
       });
 
       it('should respond with a 204 when the flag is unset', function(done) {
         supertest
-          .put('/user/' + user.userid + '/deleteflag')
+          .post('/user/' + user.userid + '/deleteflag')
           .send({password: user.password})
           .set('X-Tidepool-Session-Token')
           .expect(204)
+          .end(done);
+      });
+
+      it('should respond with a 405 when the http method is GET', function(done) {
+        supertest
+          .get('/user/' + user.userid + '/deleteflag')
+          .send({password: user.password})
+          .set('X-Tidepool-Session-Token')
+          .expect(405)
+          .end(done);
+      });
+
+      it('should respond with a 405 when the http method is PUT', function(done) {
+        supertest
+          .put('/user/' + user.userid + '/deleteflag')
+          .send({password: user.password})
+          .set('X-Tidepool-Session-Token')
+          .expect(405)
           .end(done);
       });
     });

--- a/test/test_user_api_unit.js
+++ b/test/test_user_api_unit.js
@@ -985,7 +985,7 @@ describe('userapi', function () {
         supertest
           .del('/user/' + user.userid + '/deleteflag')
           .send({password: 'abc1234'})
-          .set('X-Tidepool-Session-Token')
+          .set('X-Tidepool-Session-Token', serverToken)
           .expect(403)
           .end(done);
       });
@@ -1003,7 +1003,7 @@ describe('userapi', function () {
         supertest
           .post('/user/' + user.userid + '/deleteflag')
           .send({password: user.password})
-          .set('X-Tidepool-Session-Token')
+          .set('X-Tidepool-Session-Token', serverToken)
           .expect(204)
           .end(done);
       });
@@ -1012,7 +1012,7 @@ describe('userapi', function () {
         supertest
           .get('/user/' + user.userid + '/deleteflag')
           .send({password: user.password})
-          .set('X-Tidepool-Session-Token')
+          .set('X-Tidepool-Session-Token', serverToken)
           .expect(405)
           .end(done);
       });
@@ -1021,7 +1021,7 @@ describe('userapi', function () {
         supertest
           .put('/user/' + user.userid + '/deleteflag')
           .send({password: user.password})
-          .set('X-Tidepool-Session-Token')
+          .set('X-Tidepool-Session-Token', serverToken)
           .expect(405)
           .end(done);
       });

--- a/test/test_user_api_unit.js
+++ b/test/test_user_api_unit.js
@@ -906,20 +906,20 @@ describe('userapi', function () {
     describe('User delete flag set/unset', function() {
       it('should respond with a 401 if no session token is present', function(done) {
         supertest
-          .delete('/user/'+ user.userid + '/deleteflag')
+          .del('/user/'+ user.userid + '/deleteflag')
           .expect(401, done);
       });
 
       it('should respond with a 403 if the users password is null', function(done) {
         supertest
-          .delete('/user/' + user.userid + '/deleteflag')
+          .del('/user/' + user.userid + '/deleteflag')
           .set('X-Tidepool-Session-Token', serverToken)
           .expect(403, done);
       });
 
       it('should respond with a 403 if the users password is wrong', function(done) {
         supertest
-          .delete('/user/' + user.userid + '/deleteflag')
+          .del('/user/' + user.userid + '/deleteflag')
           .send({password: 'abc1234'})
           .set('X-Tidepool-Session-Token')
           .expect(403)
@@ -928,7 +928,7 @@ describe('userapi', function () {
 
       it('should respond with a 202 when the flag is set', function(done) {
         supertest
-          .delete('/user/' + user.userid + '/deleteflag')
+          .del('/user/' + user.userid + '/deleteflag')
           .send({password: user.password})
           .set('X-Tidepool-Session-Token', serverToken)
           .expect(202)

--- a/test/test_user_api_unit.js
+++ b/test/test_user_api_unit.js
@@ -968,7 +968,6 @@ describe('userapi', function () {
     });
 
     describe('User delete flag set/unset', function() {
-      var workingPw = 'bluebayou';
       it('should respond with a 401 if no session token is present', function(done) {
         supertest
           .del('/user/'+ user.userid + '/deleteflag')

--- a/test/test_user_api_unit.js
+++ b/test/test_user_api_unit.js
@@ -906,32 +906,59 @@ describe('userapi', function () {
     describe('User delete flag set/unset', function() {
       it('should respond with a 401 if no session token is present', function(done) {
         supertest
-          .post('/user/'+ user.userid + '/deleteflag')
+          .delete('/user/'+ user.userid + '/deleteflag')
           .expect(401, done);
       });
 
       it('should respond with a 403 if the users password is null', function(done) {
         supertest
-          .post('/user/' + user.userid + '/deleteflag')
+          .delete('/user/' + user.userid + '/deleteflag')
           .set('X-Tidepool-Session-Token', serverToken)
           .expect(403, done);
       });
 
-      it('should respond with a 200 when the flag is set', function(done) {
+      it('should respond with a 403 if the users password is wrong', function(done) {
         supertest
-          .post('/user/' + user.userid + '/deleteflag')
+          .delete('/user/' + user.userid + '/deleteflag')
+          .send({password: 'abc1234'})
+          .set('X-Tidepool-Session-Token')
+          .expect(403)
+          .end(done);
+      });
+
+      it('should respond with a 202 when the flag is set', function(done) {
+        supertest
+          .delete('/user/' + user.userid + '/deleteflag')
           .send({password: user.password})
           .set('X-Tidepool-Session-Token', serverToken)
-          .expect(200)
+          .expect(202)
           .end(done);
       });
 
       it('should respond with a 204 when the flag is unset', function(done) {
         supertest
-          .put('/user/' + user.userid + '/deleteflag')
+          .post('/user/' + user.userid + '/deleteflag')
           .send({password: user.password})
           .set('X-Tidepool-Session-Token')
           .expect(204)
+          .end(done);
+      });
+
+      it('should respond with a 405 when the http method is GET', function(done) {
+        supertest
+          .get('/user/' + user.userid + '/deleteflag')
+          .send({password: user.password})
+          .set('X-Tidepool-Session-Token')
+          .expect(405)
+          .end(done);
+      });
+
+      it('should respond with a 405 when the http method is PUT', function(done) {
+        supertest
+          .put('/user/' + user.userid + '/deleteflag')
+          .send({password: user.password})
+          .set('X-Tidepool-Session-Token')
+          .expect(405)
           .end(done);
       });
     });

--- a/test/test_user_api_unit.js
+++ b/test/test_user_api_unit.js
@@ -34,7 +34,8 @@ var env = {
     error: console.log,
     warn: console.log,
     info: console.log
-  }
+  },
+  deleteWindow: 14
 };
 
 var dbmongo = require('../lib/db_mongo.js')(env);
@@ -860,50 +861,7 @@ describe('userapi', function () {
 
     });
 
-    describe('POST /logout with valid session token', function () {
-
-      it('should respond with 200 and log out', function (done) {
-        supertest
-          .post('/logout')
-          .set('X-Tidepool-Session-Token', sessionToken)
-          .expect(200)
-          .end(done);
-      });
-
-    });
-
-    describe('DELETE /user/:id for server without password', function () {
-      it('should respond with 403', function (done) {
-        supertest
-          .del('/user/' + user.userid)
-          .set('X-Tidepool-Session-Token', serverToken)
-          .expect(403)
-          .end(done);
-      });
-    });
-
-    describe('DELETE /user/:id for server with bad userid', function () {
-      it('should respond with 403', function (done) {
-        supertest
-          .del('/user/' + 'a123af')
-          .set('X-Tidepool-Session-Token', serverToken)
-          .expect(403)
-          .end(done);
-      });
-    });
-
-    describe('DELETE /user/:id for server with password', function () {
-      it('should respond with 200', function (done) {
-        supertest
-          .del('/user/' + user.userid)
-          .send({password: user.password})
-          .set('X-Tidepool-Session-Token', serverToken)
-          .expect(200)
-          .end(done);
-      });
-    });
-
-    describe('User delete flag set/unset', function() {
+    describe('Test user delete flag set/unset functionality', function() {
       it('should respond with a 401 if no session token is present', function(done) {
         supertest
           .del('/user/'+ user.userid + '/deleteflag')
@@ -960,6 +918,49 @@ describe('userapi', function () {
           .send({password: user.password})
           .set('X-Tidepool-Session-Token', serverToken)
           .expect(405)
+          .end(done);
+      });
+    });
+
+    describe('POST /logout with valid session token', function () {
+
+      it('should respond with 200 and log out', function (done) {
+        supertest
+          .post('/logout')
+          .set('X-Tidepool-Session-Token', sessionToken)
+          .expect(200)
+          .end(done);
+      });
+
+    });
+
+    describe('DELETE /user/:id for server without password', function () {
+      it('should respond with 403', function (done) {
+        supertest
+          .del('/user/' + user.userid)
+          .set('X-Tidepool-Session-Token', serverToken)
+          .expect(403)
+          .end(done);
+      });
+    });
+
+    describe('DELETE /user/:id for server with bad userid', function () {
+      it('should respond with 403', function (done) {
+        supertest
+          .del('/user/' + 'a123af')
+          .set('X-Tidepool-Session-Token', serverToken)
+          .expect(403)
+          .end(done);
+      });
+    });
+
+    describe('DELETE /user/:id for server with password', function () {
+      it('should respond with 200', function (done) {
+        supertest
+          .del('/user/' + user.userid)
+          .send({password: user.password})
+          .set('X-Tidepool-Session-Token', serverToken)
+          .expect(200)
           .end(done);
       });
     });

--- a/test/test_user_api_unit.js
+++ b/test/test_user_api_unit.js
@@ -967,7 +967,38 @@ describe('userapi', function () {
       });
     });
 
+    describe('User delete flag set/unset', function() {
+      it('should respond with a 401 if no session token is present', function(done) {
+        supertest
+          .post('/user/'+ user.userid + '/deleteflag')
+          .expect(401);
+      });
 
+      it('should respond with a 403 if the users password is null', function(done) {
+        supertest
+          .post('/user/' + user.userid + '/deleteflag')
+          .set('X-Tidepool-Session-Token', serverToken)
+          .expect(403);
+      });
+
+      it('should respond with a 200 when the flag is set', function(done) {
+        supertest
+          .post('/user/' + user.userid + '/deleteflag')
+          .send({password: user.password})
+          .set('X-Tidepool-Session-Token', serverToken)
+          .expect(200)
+          .end(done);
+      });
+
+      it('should respond with a 204 when the flag is unset', function(done) {
+        supertest
+          .put('/user/' + user.userid + '/deleteflag')
+          .send({password: user.password})
+          .set('X-Tidepool-Session-Token')
+          .expect(204)
+          .end(done);
+      });
+    });
 
     describe('POST /logout with valid server token', function () {
 

--- a/test/test_user_api_unit.js
+++ b/test/test_user_api_unit.js
@@ -971,7 +971,8 @@ describe('userapi', function () {
       it('should respond with a 401 if no session token is present', function(done) {
         supertest
           .del('/user/'+ user.userid + '/deleteflag')
-          .expect(401, done);
+          .expect(401)
+          .end(done);
       });
 
       it('should respond with a 403 if the users password is null', function(done) {
@@ -984,7 +985,7 @@ describe('userapi', function () {
       it('should respond with a 403 if the users password is wrong', function(done) {
         supertest
           .del('/user/' + user.userid + '/deleteflag')
-          .send({password: 'abc1234'})
+          .send({password: 'badpass'})
           .set('X-Tidepool-Session-Token', serverToken)
           .expect(403)
           .end(done);

--- a/test/test_user_api_unit.js
+++ b/test/test_user_api_unit.js
@@ -907,7 +907,8 @@ describe('userapi', function () {
       it('should respond with a 401 if no session token is present', function(done) {
         supertest
           .del('/user/'+ user.userid + '/deleteflag')
-          .expect(401, done);
+          .expect(401)
+          .end(done);
       });
 
       it('should respond with a 403 if the users password is null', function(done) {
@@ -920,7 +921,7 @@ describe('userapi', function () {
       it('should respond with a 403 if the users password is wrong', function(done) {
         supertest
           .del('/user/' + user.userid + '/deleteflag')
-          .send({password: 'abc1234'})
+          .send({password: 'badpass'})
           .set('X-Tidepool-Session-Token', serverToken)
           .expect(403)
           .end(done);

--- a/test/test_user_api_unit.js
+++ b/test/test_user_api_unit.js
@@ -968,6 +968,7 @@ describe('userapi', function () {
     });
 
     describe('User delete flag set/unset', function() {
+      var workingPw = 'bluebayou';
       it('should respond with a 401 if no session token is present', function(done) {
         supertest
           .del('/user/'+ user.userid + '/deleteflag')

--- a/test/test_user_api_unit.js
+++ b/test/test_user_api_unit.js
@@ -904,6 +904,7 @@ describe('userapi', function () {
     });
 
     describe('User delete flag set/unset', function() {
+      var workingPw = 'bluebayou';
       it('should respond with a 401 if no session token is present', function(done) {
         supertest
           .del('/user/'+ user.userid + '/deleteflag')

--- a/test/test_user_api_unit.js
+++ b/test/test_user_api_unit.js
@@ -907,14 +907,14 @@ describe('userapi', function () {
       it('should respond with a 401 if no session token is present', function(done) {
         supertest
           .post('/user/'+ user.userid + '/deleteflag')
-          .expect(401);
+          .expect(401, done);
       });
 
       it('should respond with a 403 if the users password is null', function(done) {
         supertest
           .post('/user/' + user.userid + '/deleteflag')
           .set('X-Tidepool-Session-Token', serverToken)
-          .expect(403);
+          .expect(403, done);
       });
 
       it('should respond with a 200 when the flag is set', function(done) {

--- a/test/test_user_api_unit.js
+++ b/test/test_user_api_unit.js
@@ -971,14 +971,14 @@ describe('userapi', function () {
       it('should respond with a 401 if no session token is present', function(done) {
         supertest
           .post('/user/'+ user.userid + '/deleteflag')
-          .expect(401);
+          .expect(401, done);
       });
 
       it('should respond with a 403 if the users password is null', function(done) {
         supertest
           .post('/user/' + user.userid + '/deleteflag')
           .set('X-Tidepool-Session-Token', serverToken)
-          .expect(403);
+          .expect(403, done);
       });
 
       it('should respond with a 200 when the flag is set', function(done) {

--- a/test/test_user_api_unit.js
+++ b/test/test_user_api_unit.js
@@ -39,7 +39,7 @@ var env = {
     error: savelog,
     warn: savelog,
     info: savelog
-  }
+  },
   deleteWindow: 14
 };
 

--- a/test/test_user_api_unit.js
+++ b/test/test_user_api_unit.js
@@ -921,7 +921,7 @@ describe('userapi', function () {
         supertest
           .del('/user/' + user.userid + '/deleteflag')
           .send({password: 'abc1234'})
-          .set('X-Tidepool-Session-Token')
+          .set('X-Tidepool-Session-Token', serverToken)
           .expect(403)
           .end(done);
       });
@@ -939,7 +939,7 @@ describe('userapi', function () {
         supertest
           .post('/user/' + user.userid + '/deleteflag')
           .send({password: user.password})
-          .set('X-Tidepool-Session-Token')
+          .set('X-Tidepool-Session-Token', serverToken)
           .expect(204)
           .end(done);
       });
@@ -948,7 +948,7 @@ describe('userapi', function () {
         supertest
           .get('/user/' + user.userid + '/deleteflag')
           .send({password: user.password})
-          .set('X-Tidepool-Session-Token')
+          .set('X-Tidepool-Session-Token', serverToken)
           .expect(405)
           .end(done);
       });
@@ -957,7 +957,7 @@ describe('userapi', function () {
         supertest
           .put('/user/' + user.userid + '/deleteflag')
           .send({password: user.password})
-          .set('X-Tidepool-Session-Token')
+          .set('X-Tidepool-Session-Token', serverToken)
           .expect(405)
           .end(done);
       });


### PR DESCRIPTION
Added API method `setDeleteFlag` that will respond to `DELETE` or `POST` HTTP methods (`DELETE` being used for setting the flag, `POST` being used for resetting it to an empty string).

Open for revisions before it is ready for a merge - to be honest, it probably needs them...

@kentquirk 
Issue reference: #12 
